### PR TITLE
v1.4.1 Release

### DIFF
--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -23,18 +23,18 @@ jobs:
       id-token: write
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.2"
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -42,14 +42,14 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Test coverage Reports
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: code-coverage-report
           path: |
@@ -79,13 +79,13 @@ jobs:
 
       - name: Go Coverage Badge
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: tj-actions/coverage-badge-go@v2
+        uses: tj-actions/coverage-badge-go@84540b9f82b4f569ac9f248cf6f2893ac3cc4791 # v2
         with:
           filename: ./reports/coverage.out
 
       - name: Verify Changed files
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: tj-actions/verify-changed-files@v12
+        uses: tj-actions/verify-changed-files@a3391b5a01114c49c3a8d55181a9ff4c99bf0db7 # v12
         id: verify-changed-files
         with:
           files: README.md
@@ -107,11 +107,11 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
       - name: Checkout SolaceDev/maas-build-actions
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: SolaceDev/maas-build-actions
           ref: refs/heads/master
@@ -122,7 +122,7 @@ jobs:
       - name: Retrieve google container registry secrets
         id: docker_registry_secrets
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: hashicorp/vault-action@v2.5.0
+        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e # v2.5.0
         with:
           url: "${{ env.VAULT_ADDR }}"
           role: github-docker-secrets-read-role
@@ -147,7 +147,7 @@ jobs:
           password: ${{ steps.docker_registry_secrets.outputs.GCP_DEV_SERVICE_ACCOUNT }}
 
       - name: Build image and push Google Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
         with:
           context: ./
@@ -174,7 +174,7 @@ jobs:
 
 
       - name: Run Whitesource Action
-        uses: SolaceDev/Mend-Scan-GHA@v1.0.0
+        uses: SolaceDev/Mend-Scan-GHA@eee5b469b9fa9298d8dd02a92e42525ff015c3da # v1.0.0
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
         with:
           wssURL: https://saas.whitesourcesoftware.com/agent
@@ -184,7 +184,7 @@ jobs:
           configFile: 'ci/whitesource/whitesource-agent.config'
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
@@ -194,14 +194,14 @@ jobs:
 
       - name: Uploads Trivy Scan Reports
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-results
           path: |
             trivy-results.sarif
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
@@ -211,7 +211,7 @@ jobs:
 
       - name: Uploads Trivy Scan Reports
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           path: |
             trivy-results.sarif

--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -173,16 +173,6 @@ jobs:
 #          prisma_jira_check: "False"
 
 
-      - name: Run Whitesource Action
-        uses: SolaceDev/Mend-Scan-GHA@eee5b469b9fa9298d8dd02a92e42525ff015c3da # v1.0.0
-        if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
-        with:
-          wssURL: https://saas.whitesourcesoftware.com/agent
-          apiKey: ${{ secrets.WSS_API_KEY }}
-          productName: 'pubsubplus-kubernetes-operator'
-          projectName: 'pubsubplus-kubernetes-operator'
-          configFile: 'ci/whitesource/whitesource-agent.config'
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}

--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 1.4.0
+  VERSION: 1.4.1
   IMAGE_NAME: pubsubplus-eventbroker-operator
   VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
   GCLOUD_PROJECT_ID_DEV: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/build-test-dev.yml
+++ b/.github/workflows/build-test-dev.yml
@@ -184,7 +184,7 @@ jobs:
           configFile: 'ci/whitesource/whitesource-agent.config'
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
@@ -201,7 +201,7 @@ jobs:
             trivy-results.sarif
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         if: ${{ startsWith(github.ref_name, 'dev1.') && (github.ref_name != 'main') }}
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/main-branch-only.yml
+++ b/.github/workflows/main-branch-only.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.3.0
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d # v1.3.0
 
       - name: Testing operator deployment
         run: |

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -4,7 +4,7 @@ on:
       release_tag:
         description: 'Release tag'
         required: true
-        default: '1.4.0'
+        default: '1.4.1'
       prep_internal_release:
         # Need to distinguish between internal and external releases
         # Internal release: Will use default internal location for created images (ghcr.io) and will tag and push operator candidate there

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -22,19 +22,19 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24.2
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup tools
         run: |
@@ -81,7 +81,7 @@ jobs:
           make bundle
 
       - name: Prep for testing - create K8s Kind Cluster
-        uses: helm/kind-action@v1.3.0
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d # v1.3.0
 
       - name: Test operator image using preflight tool
         run: |
@@ -114,7 +114,7 @@ jobs:
           docker push `echo $CATALOG | awk '{print $1}'`:latest
 
       - name: Run Whitesource Action
-        uses: SolaceDev/Mend-Scan-GHA@v1.0.0
+        uses: SolaceDev/Mend-Scan-GHA@eee5b469b9fa9298d8dd02a92e42525ff015c3da # v1.0.0
         with:
           wssURL: https://saas.whitesourcesoftware.com/agent
           apiKey: ${{ secrets.WSS_API_KEY }}
@@ -123,7 +123,7 @@ jobs:
           configFile: 'ci/whitesource/whitesource-agent.config'
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:
           committer_name: GitHub Actions
           committer_email: actions@github.com

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -113,15 +113,6 @@ jobs:
           docker tag `echo $CATALOG | awk '{print $3}'` `echo $CATALOG | awk '{print $1}'`:latest
           docker push `echo $CATALOG | awk '{print $1}'`:latest
 
-      - name: Run Whitesource Action
-        uses: SolaceDev/Mend-Scan-GHA@eee5b469b9fa9298d8dd02a92e42525ff015c3da # v1.0.0
-        with:
-          wssURL: https://saas.whitesourcesoftware.com/agent
-          apiKey: ${{ secrets.WSS_API_KEY }}
-          productName: 'pubsubplus-kubernetes-operator'
-          projectName: 'pubsubplus-kubernetes-operator'
-          configFile: 'ci/whitesource/whitesource-agent.config'
-
       - name: Commit changes
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:

--- a/.github/workflows/test-broker-chaos-situation.yml
+++ b/.github/workflows/test-broker-chaos-situation.yml
@@ -19,27 +19,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-chaos-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-broker-upgrade-update.yml
+++ b/.github/workflows/test-broker-upgrade-update.yml
@@ -18,27 +18,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-upgrade-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-full-params-ha.yml
+++ b/.github/workflows/test-full-params-ha.yml
@@ -19,27 +19,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-full-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-full-params.yml
+++ b/.github/workflows/test-full-params.yml
@@ -19,27 +19,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-fnha-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-helm-upgrade.yml
+++ b/.github/workflows/test-helm-upgrade.yml
@@ -18,27 +18,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-helm-upgrade-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-minimal-params-ha.yml
+++ b/.github/workflows/test-minimal-params-ha.yml
@@ -19,27 +19,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-min-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-minimal-params.yml
+++ b/.github/workflows/test-minimal-params.yml
@@ -19,27 +19,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-mnha-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-nodeport.yml
+++ b/.github/workflows/test-nodeport.yml
@@ -18,27 +18,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-nodeport-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-taints-and-toleration.yml
+++ b/.github/workflows/test-taints-and-toleration.yml
@@ -19,27 +19,27 @@ jobs:
           echo "TESTNAMESPACE=op-test-full-$(date +%s)" >> $GITHUB_ENV
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           access_token_lifetime: 600s
 
       - name: Use the GKE Autopilot test cluster
-        uses: 'google-github-actions/get-gke-credentials@v1.0.0'
+        uses: google-github-actions/get-gke-credentials@ef10cc0013c465a6ea0b8e36c24064576ec25f87 # v1.0.0
         with:
           cluster_name: 'dev-integrationtesting'
           location: 'us-central1'
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/vulncheck_periodic.yml
+++ b/.github/workflows/vulncheck_periodic.yml
@@ -112,7 +112,7 @@ jobs:
           configFile: 'ci/whitesource/whitesource-agent.config'
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           format: 'sarif'
@@ -127,7 +127,7 @@ jobs:
             trivy-results.sarif
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           format: 'sarif'

--- a/.github/workflows/vulncheck_periodic.yml
+++ b/.github/workflows/vulncheck_periodic.yml
@@ -102,15 +102,6 @@ jobs:
       - name: Build image and push GitHub Container Registry
         run: make docker-push
 
-      - name: Run Whitesource Action
-        uses: SolaceDev/Mend-Scan-GHA@eee5b469b9fa9298d8dd02a92e42525ff015c3da # v1.0.0
-        with:
-          wssURL: https://saas.whitesourcesoftware.com/agent
-          apiKey: ${{ secrets.WSS_API_KEY }}
-          productName: 'pubsubplus-kubernetes-operator'
-          projectName: 'pubsubplus-kubernetes-operator'
-          configFile: 'ci/whitesource/whitesource-agent.config'
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:

--- a/.github/workflows/vulncheck_periodic.yml
+++ b/.github/workflows/vulncheck_periodic.yml
@@ -25,15 +25,15 @@ jobs:
       id-token: write
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.2"
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -41,10 +41,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
       - name: Checkout SolaceDev/maas-build-actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: SolaceDev/maas-build-actions
           ref: refs/heads/master
@@ -54,7 +54,7 @@ jobs:
 
       - name: Retrieve google container registry secrets
         id: docker_registry_secrets
-        uses: hashicorp/vault-action@v2.5.0
+        uses: hashicorp/vault-action@130d1f5f4fe645bb6c83e4225c04d64cfb62de6e # v2.5.0
         with:
           url: "${{ env.VAULT_ADDR }}"
           role: github-docker-secrets-read-role
@@ -78,7 +78,7 @@ jobs:
           password: ${{ steps.docker_registry_secrets.outputs.GCP_DEV_SERVICE_ACCOUNT }}
 
       - name: Build image and push Google Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: ./
           tags: |
@@ -103,7 +103,7 @@ jobs:
         run: make docker-push
 
       - name: Run Whitesource Action
-        uses: SolaceDev/Mend-Scan-GHA@v1.0.0
+        uses: SolaceDev/Mend-Scan-GHA@eee5b469b9fa9298d8dd02a92e42525ff015c3da # v1.0.0
         with:
           wssURL: https://saas.whitesourcesoftware.com/agent
           apiKey: ${{ secrets.WSS_API_KEY }}
@@ -112,7 +112,7 @@ jobs:
           configFile: 'ci/whitesource/whitesource-agent.config'
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           format: 'sarif'
@@ -121,13 +121,13 @@ jobs:
 
       - name: Uploads Trivy Scan Reports
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           path: |
             trivy-results.sarif
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:
           image-ref: ghcr.io/solacedev/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           format: 'sarif'
@@ -136,7 +136,7 @@ jobs:
 
       - name: Uploads Trivy Scan Reports
         if: ${{ !startsWith(github.ref_name, '1.') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           path: |
             trivy-results.sarif

--- a/.github/workflows/vulncheck_periodic.yml
+++ b/.github/workflows/vulncheck_periodic.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 */ * * *'
 
 env:
-  VERSION: 1.4.0
+  VERSION: 1.4.1
   IMAGE_NAME: pubsubplus-eventbroker-operator
   VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
   GCLOUD_PROJECT_ID_DEV: ${{ secrets.GCLOUD_PROJECT_ID }}
@@ -65,7 +65,7 @@ jobs:
           secrets: |
             secret/data/development/gcp-gcr GCP_SERVICE_ACCOUNT | GCP_DEV_SERVICE_ACCOUNT
         env:
-          VERSION: 1.4.0
+          VERSION: 1.4.1
           IMAGE_NAME: pubsubplus-eventbroker-operator
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           GCLOUD_PROJECT_ID_DEV: ${{ secrets.GCLOUD_PROJECT_ID }}
@@ -85,7 +85,7 @@ jobs:
             gcr.io/${{ env.GCLOUD_PROJECT_ID_DEV }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           push: true
         env:
-          VERSION: 1.4.0
+          VERSION: 1.4.1
           IMAGE_NAME: pubsubplus-eventbroker-operator
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           GCLOUD_PROJECT_ID_DEV: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754000177
 LABEL name="solace/pubsubplus-eventbroker-operator"
 LABEL maintainer="Solace Corporation"
 LABEL vendor="Solace Corporation"
-LABEL version="1.4.0"
-LABEL release="1.4.0"
+LABEL version="1.4.1"
+LABEL release="1.4.1"
 LABEL summary="Solace PubSub+ Event Broker Kubernetes Operator"
 LABEL description="The Solace PubSub+ Event Broker Kubernetes Operator deploys and manages the lifecycle of PubSub+ Event Brokers"
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.4.0
+VERSION ?= 1.4.1
 
 # API_VERSION defines the API version for the PubSubPlusEventBroker CRD
 API_VERSION ?= v1beta1

--- a/bundle/manifests/pubsubplus-eventbroker-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pubsubplus-eventbroker-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     certified: "true"
     com.redhat.delivery.operator.bundle: "true"
     com.redhat.openshift.versions: v4.10
-    containerImage: docker.io/solace/pubsubplus-eventbroker-operator:1.4.0
+    containerImage: docker.io/solace/pubsubplus-eventbroker-operator:1.4.1
     createdAt: "2025-07-31T19:48:36Z"
     description: The Solace PubSub+ Event Broker Operator deploys and manages the
       lifecycle of PubSub+ Event Brokers
@@ -29,7 +29,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/SolaceProducts/pubsubplus-kubernetes-quickstart
     support: Solace Products
-  name: pubsubplus-eventbroker-operator.v1.4.0
+  name: pubsubplus-eventbroker-operator.v1.4.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -296,7 +296,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: docker.io/solace/pubsubplus-eventbroker-operator:1.4.0
+                image: docker.io/solace/pubsubplus-eventbroker-operator:1.4.1
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -411,4 +411,4 @@ spec:
   provider:
     name: Solace Corporation
     url: www.solace.com
-  version: 1.4.0
+  version: 1.4.1

--- a/bundle/manifests/pubsubplus.solace.com_pubsubpluseventbrokers.yaml
+++ b/bundle/manifests/pubsubplus.solace.com_pubsubpluseventbrokers.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
-    app.kubernetes.io/version: v1.4.0
+    app.kubernetes.io/version: v1.4.1
   name: pubsubpluseventbrokers.pubsubplus.solace.com
 spec:
   group: pubsubplus.solace.com

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,4 +11,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/solacedev/pubsubplus-eventbroker-operator
-  newTag: 1.4.0
+  newTag: 1.4.1

--- a/config/manifests/bases/pubsubplus-eventbroker-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pubsubplus-eventbroker-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "true"
     com.redhat.delivery.operator.bundle: "true"
     com.redhat.openshift.versions: v4.10
-    containerImage: docker.io/solace/pubsubplus-eventbroker-operator:v1.4.0
+    containerImage: docker.io/solace/pubsubplus-eventbroker-operator:v1.4.1
     createdAt: "2023-03-31T12:00:00.000Z"
     description: The Solace PubSub+ Event Broker Operator deploys and manages the
       lifecycle of PubSub+ Event Brokers

--- a/controllers/controller_utils.go
+++ b/controllers/controller_utils.go
@@ -86,6 +86,45 @@ func tlsSecretUpToDate(recorded string, expectedTlsSecretHash string, legacyReso
 		(legacyResourceVersion != "" && recorded == legacyResourceVersion)
 }
 
+func needsTlsAnnotationMigration(recorded string, contentHash string, currentResourceVersion string) bool {
+	return contentHash != "" && recorded != "" && recorded != contentHash && recorded == currentResourceVersion
+}
+
+func (r *PubSubPlusEventBrokerReconciler) migrateLegacyTlsAnnotations(ctx context.Context, m *eventbrokerv1beta1.PubSubPlusEventBroker, stss []*appsv1.StatefulSet, contentHash string, currentResourceVersion string) error {
+	if contentHash == "" {
+		return nil
+	}
+	for _, sts := range stss {
+		if sts == nil {
+			continue
+		}
+		if needsTlsAnnotationMigration(sts.Spec.Template.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName], contentHash, currentResourceVersion) {
+			sts.Spec.Template.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName] = contentHash
+			if err := r.Update(ctx, sts); err != nil {
+				return err
+			}
+		}
+	}
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(m.Namespace),
+		client.MatchingLabels(getDiscoveryServiceSelector(m.Name)),
+	}
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return err
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if needsTlsAnnotationMigration(pod.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName], contentHash, currentResourceVersion) {
+			pod.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName] = contentHash
+			if err := r.Update(ctx, pod); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func brokerSpecHash(s eventbrokerv1beta1.EventBrokerSpec) string {
 	brokerSpecSubset := s.DeepCopy()
 	// Mask anything that is not relevant to the StatefulSet / broker Pods

--- a/controllers/controller_utils.go
+++ b/controllers/controller_utils.go
@@ -19,17 +19,19 @@ package controllers
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"embed"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	eventbrokerv1beta1 "github.com/SolaceProducts/pubsubplus-operator/api/v1beta1"
 	"hash/crc64"
+	"strconv"
+
+	eventbrokerv1beta1 "github.com/SolaceProducts/pubsubplus-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 var (
@@ -54,18 +56,34 @@ func (r *PubSubPlusEventBrokerReconciler) getBrokerPod(ctx context.Context, m *e
 	return nil, fmt.Errorf("filtered broker pod list for broker role %d didn't return exactly one pod", brokerRole)
 }
 
-// Returns the TLS secret resourceVersion if it exists. If TLS is not configured or TLS secret not found it returns empty string
-func (r *PubSubPlusEventBrokerReconciler) tlsSecretHash(ctx context.Context, m *eventbrokerv1beta1.PubSubPlusEventBroker) string {
-	var tlsSecretVersion string = ""
-	if m.Spec.BrokerTLS.ServerTLsConfigSecret != "" {
-		secretName := m.Spec.BrokerTLS.ServerTLsConfigSecret
-		foundSecret := &corev1.Secret{}
-		err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: m.Namespace}, foundSecret)
-		if err == nil {
-			tlsSecretVersion = foundSecret.ResourceVersion
-		}
+// Returns a hash of the TLS secret contents plus its resourceVersion (kept only for upgrade compatibility, see tlsSecretUpToDate).
+func (r *PubSubPlusEventBrokerReconciler) tlsSecretHash(ctx context.Context, m *eventbrokerv1beta1.PubSubPlusEventBroker) (contentHash string, resourceVersion string) {
+	if !m.Spec.BrokerTLS.Enabled || m.Spec.BrokerTLS.ServerTLsConfigSecret == "" {
+		return "", ""
 	}
-	return tlsSecretVersion
+	foundSecret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: m.Spec.BrokerTLS.ServerTLsConfigSecret, Namespace: m.Namespace}, foundSecret)
+	if err != nil {
+		return "", ""
+	}
+	return secretDataHash(foundSecret), foundSecret.ResourceVersion
+}
+
+func secretDataHash(secret *corev1.Secret) string {
+	serialized, err := json.Marshal(secret.Data)
+	if err != nil {
+		return ""
+	}
+	salted := fmt.Sprintf("%s/%s|%s", secret.Namespace, secret.Name, serialized)
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(salted)))
+}
+
+func tlsSecretUpToDate(recorded string, expectedTlsSecretHash string, legacyResourceVersion string) bool {
+	if expectedTlsSecretHash == "" {
+		return true
+	}
+	return recorded == expectedTlsSecretHash ||
+		(legacyResourceVersion != "" && recorded == legacyResourceVersion)
 }
 
 func brokerSpecHash(s eventbrokerv1beta1.EventBrokerSpec) string {
@@ -97,22 +115,18 @@ func brokerServiceOutdated(service *corev1.Service, expectedBrokerServiceHash st
 	return result
 }
 
-func brokerStsOutdated(sts *appsv1.StatefulSet, expectedBrokerSpecHash string, expectedTlsSecretHash string) bool {
-	result := sts.Spec.Template.ObjectMeta.Annotations[brokerSpecSignatureAnnotationName] != expectedBrokerSpecHash
-	// Ignore expectedTlsSecretHash if it is an empty string. This means the sts is not marked as outdated if the secret does not exist or has been deleted
-	if expectedTlsSecretHash != "" {
-		result = result || (sts.Spec.Template.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName] != expectedTlsSecretHash)
+func brokerStsOutdated(sts *appsv1.StatefulSet, expectedBrokerSpecHash string, expectedTlsSecretHash string, legacyTlsSecretResourceVersion string) bool {
+	if sts.Spec.Template.ObjectMeta.Annotations[brokerSpecSignatureAnnotationName] != expectedBrokerSpecHash {
+		return true
 	}
-	return result
+	return !tlsSecretUpToDate(sts.Spec.Template.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName], expectedTlsSecretHash, legacyTlsSecretResourceVersion)
 }
 
-func brokerPodOutdated(pod *corev1.Pod, expectedBrokerSpecHash string, expectedTlsSecretHash string) bool {
-	result := pod.ObjectMeta.Annotations[brokerSpecSignatureAnnotationName] != expectedBrokerSpecHash
-	// Ignore expectedTlsSecretHash if it is an empty string. This means the pod is not marked as outdated if the secret does not exist or has been deleted
-	if expectedTlsSecretHash != "" {
-		result = result || (pod.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName] != expectedTlsSecretHash)
+func brokerPodOutdated(pod *corev1.Pod, expectedBrokerSpecHash string, expectedTlsSecretHash string, legacyTlsSecretResourceVersion string) bool {
+	if pod.ObjectMeta.Annotations[brokerSpecSignatureAnnotationName] != expectedBrokerSpecHash {
+		return true
 	}
-	return result
+	return !tlsSecretUpToDate(pod.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName], expectedTlsSecretHash, legacyTlsSecretResourceVersion)
 }
 
 func brokerMonitoringOutdated(monitoring *appsv1.Deployment, expectedMonitoringSpecHash string) bool {

--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -54,7 +54,6 @@ func testBrokerWithTls(namespace string, tlsEnabled bool, tlsSecretName string) 
 	}
 }
 
-// Regression test for the core bug: the hash must depend only on the secret contents, not metadata.
 func TestSecretDataHashStableAcrossMetadataChanges(t *testing.T) {
 	data := map[string][]byte{
 		"tls.crt": []byte("dummy-cert"),

--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -179,6 +180,135 @@ func TestTlsSecretUpToDate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNeedsTlsAnnotationMigration(t *testing.T) {
+	tests := []struct {
+		name                   string
+		recorded               string
+		contentHash            string
+		currentResourceVersion string
+		want                   bool
+	}{
+		{"legacy annotation matching current RV migrates", "1000", "hash-abc", "1000", true},
+		{"already hash format does not migrate", "hash-abc", "hash-abc", "1000", false},
+		{"stale RV does not migrate (content unknowable)", "900", "hash-abc", "1005", false},
+		{"empty content hash does not migrate", "1000", "", "1000", false},
+		{"empty recorded annotation does not migrate", "", "hash-abc", "1000", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsTlsAnnotationMigration(tt.recorded, tt.contentHash, tt.currentResourceVersion); got != tt.want {
+				t.Errorf("needsTlsAnnotationMigration(%q, %q, %q) = %v, want %v",
+					tt.recorded, tt.contentHash, tt.currentResourceVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrateLegacyTlsAnnotations(t *testing.T) {
+	const (
+		legacyRV    = "1000"
+		contentHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	)
+	broker := testBrokerWithTls("default", true, "my-tls-secret")
+
+	makeSts := func(tlsAnnotation string) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: broker.Name + "-p", Namespace: broker.Namespace},
+			Spec: appsv1.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							brokerSpecSignatureAnnotationName: "spec1",
+							tlsSecretSignatureAnnotationName:  tlsAnnotation,
+						},
+					},
+				},
+			},
+		}
+	}
+	makePod := func(name, tlsAnnotation string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: broker.Namespace,
+				UID:       types.UID("uid-" + name),
+				Labels:    getPodLabels(broker.Name, "message-routing-primary"),
+				Annotations: map[string]string{
+					brokerSpecSignatureAnnotationName: "spec1",
+					tlsSecretSignatureAnnotationName:  tlsAnnotation,
+				},
+			},
+		}
+	}
+
+	t.Run("restamps legacy annotations in place without recreating pods", func(t *testing.T) {
+		sts := makeSts(legacyRV)
+		pod := makePod("broker-pod-p-0", legacyRV)
+		r := &PubSubPlusEventBrokerReconciler{
+			Client: fake.NewClientBuilder().WithObjects(sts, pod).Build(),
+		}
+		ctx := context.Background()
+
+		if err := r.migrateLegacyTlsAnnotations(ctx, broker, []*appsv1.StatefulSet{sts}, contentHash, legacyRV); err != nil {
+			t.Fatalf("migrateLegacyTlsAnnotations returned error: %v", err)
+		}
+
+		gotSts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}, gotSts); err != nil {
+			t.Fatal(err)
+		}
+		if got := gotSts.Spec.Template.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName]; got != contentHash {
+			t.Errorf("sts template annotation = %q, want content hash", got)
+		}
+
+		gotPod := &corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, gotPod); err != nil {
+			t.Fatal(err)
+		}
+		if got := gotPod.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName]; got != contentHash {
+			t.Errorf("pod annotation = %q, want content hash", got)
+		}
+		if gotPod.UID != pod.UID {
+			t.Error("pod UID changed — migration must not recreate pods")
+		}
+	})
+
+	t.Run("does not touch pods with stale legacy annotation", func(t *testing.T) {
+		sts := makeSts("900")
+		pod := makePod("broker-pod-p-0", "900")
+		r := &PubSubPlusEventBrokerReconciler{
+			Client: fake.NewClientBuilder().WithObjects(sts, pod).Build(),
+		}
+		ctx := context.Background()
+
+		if err := r.migrateLegacyTlsAnnotations(ctx, broker, []*appsv1.StatefulSet{sts}, contentHash, "1005"); err != nil {
+			t.Fatalf("migrateLegacyTlsAnnotations returned error: %v", err)
+		}
+
+		gotPod := &corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, gotPod); err != nil {
+			t.Fatal(err)
+		}
+		if got := gotPod.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName]; got != "900" {
+			t.Errorf("stale pod annotation was modified to %q — must be left for the restart path", got)
+		}
+	})
+
+	t.Run("no-op when content hash is empty", func(t *testing.T) {
+		sts := makeSts(legacyRV)
+		pod := makePod("broker-pod-p-0", legacyRV)
+		r := &PubSubPlusEventBrokerReconciler{
+			Client: fake.NewClientBuilder().WithObjects(sts, pod).Build(),
+		}
+		if err := r.migrateLegacyTlsAnnotations(context.Background(), broker, []*appsv1.StatefulSet{sts}, "", legacyRV); err != nil {
+			t.Fatalf("migrateLegacyTlsAnnotations returned error: %v", err)
+		}
+		if sts.Spec.Template.ObjectMeta.Annotations[tlsSecretSignatureAnnotationName] != legacyRV {
+			t.Error("sts annotation modified despite empty content hash")
+		}
+	})
 }
 
 func TestBrokerPodOutdated(t *testing.T) {

--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2023 Solace Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	eventbrokerv1beta1 "github.com/SolaceProducts/pubsubplus-operator/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testTlsSecret(name, namespace, resourceVersion string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: resourceVersion,
+		},
+		Data: data,
+		Type: corev1.SecretTypeTLS,
+	}
+}
+
+func testBrokerWithTls(namespace string, tlsEnabled bool, tlsSecretName string) *eventbrokerv1beta1.PubSubPlusEventBroker {
+	return &eventbrokerv1beta1.PubSubPlusEventBroker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-broker",
+			Namespace: namespace,
+		},
+		Spec: eventbrokerv1beta1.EventBrokerSpec{
+			BrokerTLS: eventbrokerv1beta1.BrokerTLS{
+				Enabled:               tlsEnabled,
+				ServerTLsConfigSecret: tlsSecretName,
+			},
+		},
+	}
+}
+
+// Regression test for the core bug: the hash must depend only on the secret contents, not metadata.
+func TestSecretDataHashStableAcrossMetadataChanges(t *testing.T) {
+	data := map[string][]byte{
+		"tls.crt": []byte("dummy-cert"),
+		"tls.key": []byte("dummy-key"),
+	}
+	original := testTlsSecret("my-tls-secret", "default", "1000", data)
+	rewritten := testTlsSecret("my-tls-secret", "default", "2000", data)
+	rewritten.Labels = map[string]string{"rotated": "true"}
+	rewritten.Annotations = map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"}
+
+	if secretDataHash(original) != secretDataHash(rewritten) {
+		t.Errorf("secretDataHash changed on a content-identical rewrite: %q vs %q",
+			secretDataHash(original), secretDataHash(rewritten))
+	}
+	if secretDataHash(original) == "" {
+		t.Error("secretDataHash returned empty string for a valid secret")
+	}
+}
+
+func TestSecretDataHashChangesOnContentChange(t *testing.T) {
+	base := map[string][]byte{
+		"tls.crt": []byte("dummy-cert"),
+		"tls.key": []byte("dummy-key"),
+	}
+	baseHash := secretDataHash(testTlsSecret("my-tls-secret", "default", "1000", base))
+
+	valueChanged := map[string][]byte{
+		"tls.crt": []byte("rotated-cert"),
+		"tls.key": []byte("dummy-key"),
+	}
+	keyAdded := map[string][]byte{
+		"tls.crt": []byte("dummy-cert"),
+		"tls.key": []byte("dummy-key"),
+		"ca.crt":  []byte("dummy-ca"),
+	}
+	keyRemoved := map[string][]byte{
+		"tls.crt": []byte("dummy-cert"),
+	}
+
+	for name, data := range map[string]map[string][]byte{
+		"value changed": valueChanged,
+		"key added":     keyAdded,
+		"key removed":   keyRemoved,
+	} {
+		if secretDataHash(testTlsSecret("my-tls-secret", "default", "1000", data)) == baseHash {
+			t.Errorf("secretDataHash did not change when secret data had a %s", name)
+		}
+	}
+}
+
+func TestSecretDataHashSaltedWithNamespaceAndName(t *testing.T) {
+	data := map[string][]byte{"tls.crt": []byte("dummy-cert")}
+	a := secretDataHash(testTlsSecret("secret-a", "default", "1", data))
+	b := secretDataHash(testTlsSecret("secret-b", "default", "1", data))
+	c := secretDataHash(testTlsSecret("secret-a", "other-ns", "1", data))
+	if a == b || a == c {
+		t.Error("secretDataHash must differ for same data under different secret name or namespace")
+	}
+}
+
+func TestTlsSecretHash(t *testing.T) {
+	data := map[string][]byte{"tls.crt": []byte("dummy-cert"), "tls.key": []byte("dummy-key")}
+	secret := testTlsSecret("my-tls-secret", "default", "1000", data)
+	r := &PubSubPlusEventBrokerReconciler{
+		Client: fake.NewClientBuilder().WithObjects(secret).Build(),
+	}
+	ctx := context.Background()
+
+	t.Run("returns content hash and resourceVersion when TLS enabled and secret exists", func(t *testing.T) {
+		contentHash, resourceVersion := r.tlsSecretHash(ctx, testBrokerWithTls("default", true, "my-tls-secret"))
+		if contentHash != secretDataHash(secret) {
+			t.Errorf("contentHash = %q, want secretDataHash of the secret %q", contentHash, secretDataHash(secret))
+		}
+		if resourceVersion == "" {
+			t.Error("resourceVersion should be returned for upgrade compatibility")
+		}
+		if contentHash == resourceVersion {
+			t.Error("contentHash must not be the resourceVersion — that is the bug being fixed")
+		}
+	})
+
+	t.Run("returns empty when TLS disabled even if secret name is set", func(t *testing.T) {
+		contentHash, resourceVersion := r.tlsSecretHash(ctx, testBrokerWithTls("default", false, "my-tls-secret"))
+		if contentHash != "" || resourceVersion != "" {
+			t.Errorf("expected empty results with TLS disabled, got (%q, %q)", contentHash, resourceVersion)
+		}
+	})
+
+	t.Run("returns empty when no secret name configured", func(t *testing.T) {
+		contentHash, resourceVersion := r.tlsSecretHash(ctx, testBrokerWithTls("default", true, ""))
+		if contentHash != "" || resourceVersion != "" {
+			t.Errorf("expected empty results with no secret configured, got (%q, %q)", contentHash, resourceVersion)
+		}
+	})
+
+	t.Run("returns empty when secret is missing", func(t *testing.T) {
+		contentHash, resourceVersion := r.tlsSecretHash(ctx, testBrokerWithTls("default", true, "no-such-secret"))
+		if contentHash != "" || resourceVersion != "" {
+			t.Errorf("expected empty results for missing secret, got (%q, %q)", contentHash, resourceVersion)
+		}
+	})
+}
+
+func TestTlsSecretUpToDate(t *testing.T) {
+	tests := []struct {
+		name                  string
+		recorded              string
+		expectedTlsSecretHash string
+		legacyResourceVersion string
+		want                  bool
+	}{
+		{"content hash matches", "hash-abc", "hash-abc", "1000", true},
+		{"legacy resourceVersion matches (pre-upgrade pod)", "1000", "hash-abc", "1000", true},
+		{"neither matches (real cert change)", "hash-old", "hash-new", "2000", false},
+		{"no check when expected hash empty", "anything", "", "", true},
+		{"empty legacy resourceVersion is not a match", "", "hash-abc", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tlsSecretUpToDate(tt.recorded, tt.expectedTlsSecretHash, tt.legacyResourceVersion); got != tt.want {
+				t.Errorf("tlsSecretUpToDate(%q, %q, %q) = %v, want %v",
+					tt.recorded, tt.expectedTlsSecretHash, tt.legacyResourceVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrokerPodOutdated(t *testing.T) {
+	pod := func(specHash, tlsAnnotation string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					brokerSpecSignatureAnnotationName: specHash,
+					tlsSecretSignatureAnnotationName:  tlsAnnotation,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		pod                   *corev1.Pod
+		expectedBrokerHash    string
+		expectedTlsSecretHash string
+		legacyResourceVersion string
+		want                  bool
+	}{
+		{"up to date", pod("spec1", "hash-abc"), "spec1", "hash-abc", "1000", false},
+		{"outdated on brokerSpec mismatch alone", pod("spec-old", "hash-abc"), "spec-new", "hash-abc", "1000", true},
+		{"not outdated when annotation holds legacy resourceVersion", pod("spec1", "1000"), "spec1", "hash-abc", "1000", false},
+		{"outdated on TLS content change", pod("spec1", "hash-old"), "spec1", "hash-new", "2000", true},
+		{"TLS check skipped when secret unreadable", pod("spec1", "hash-abc"), "spec1", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := brokerPodOutdated(tt.pod, tt.expectedBrokerHash, tt.expectedTlsSecretHash, tt.legacyResourceVersion); got != tt.want {
+				t.Errorf("brokerPodOutdated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrokerStsOutdated(t *testing.T) {
+	sts := func(specHash, tlsAnnotation string) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			Spec: appsv1.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							brokerSpecSignatureAnnotationName: specHash,
+							tlsSecretSignatureAnnotationName:  tlsAnnotation,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		sts                   *appsv1.StatefulSet
+		expectedBrokerHash    string
+		expectedTlsSecretHash string
+		legacyResourceVersion string
+		want                  bool
+	}{
+		{"up to date", sts("spec1", "hash-abc"), "spec1", "hash-abc", "1000", false},
+		{"outdated on brokerSpec mismatch alone", sts("spec-old", "hash-abc"), "spec-new", "hash-abc", "1000", true},
+		{"not outdated when annotation holds legacy resourceVersion", sts("spec1", "1000"), "spec1", "hash-abc", "1000", false},
+		{"outdated on TLS content change", sts("spec1", "hash-old"), "spec1", "hash-new", "2000", true},
+		{"TLS check skipped when secret unreadable", sts("spec1", "hash-abc"), "spec1", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := brokerStsOutdated(tt.sts, tt.expectedBrokerHash, tt.expectedTlsSecretHash, tt.legacyResourceVersion); got != tt.want {
+				t.Errorf("brokerStsOutdated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/eventbroker_controller.go
+++ b/controllers/eventbroker_controller.go
@@ -436,7 +436,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 	// prep variables to be used next
 	automatedPodUpdateStrategy := (pubsubpluseventbroker.Spec.UpdateStrategy != eventbrokerv1beta1.ManualPodRestartUpdateStrategy)
 	brokerSpecHash := brokerSpecHash(pubsubpluseventbroker.Spec)
-	tlsSecretHash := r.tlsSecretHash(ctx, pubsubpluseventbroker)
+	tlsSecretHash, tlsSecretResourceVersion := r.tlsSecretHash(ctx, pubsubpluseventbroker)
 	// Check if Primary StatefulSet already exists, if not create a new one
 	stsP = &appsv1.StatefulSet{}
 	stsPName := getStatefulsetName(pubsubpluseventbroker.Name, "p")
@@ -506,7 +506,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 	// Check and address if statefulsets require update
 	if haDeployment {
 		// Monitor
-		if brokerStsOutdated(stsM, brokerSpecHash, tlsSecretHash) {
+		if brokerStsOutdated(stsM, brokerSpecHash, tlsSecretHash, tlsSecretResourceVersion) {
 			log.Info("Updating existing Monitor StatefulSet", "StatefulSet.Namespace", stsM.Namespace, "StatefulSet.Name", stsM.Name)
 			r.updateStatefulsetForEventBroker(stsM, ctx, pubsubpluseventbroker, sa, adminSecret, preSharedAuthKeySecret, monitoringSecret)
 			err = r.Update(ctx, stsM)
@@ -519,7 +519,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 		}
 		log.V(1).Info("Detected up-to-date existing Monitor StatefulSet", " StatefulSet.Name", stsM.Name)
 		// Backup
-		if brokerStsOutdated(stsB, brokerSpecHash, tlsSecretHash) {
+		if brokerStsOutdated(stsB, brokerSpecHash, tlsSecretHash, tlsSecretResourceVersion) {
 			log.Info("Updating existing Backup StatefulSet", "StatefulSet.Namespace", stsB.Namespace, "StatefulSet.Name", stsB.Name)
 			r.updateStatefulsetForEventBroker(stsB, ctx, pubsubpluseventbroker, sa, adminSecret, preSharedAuthKeySecret, monitoringSecret)
 			err = r.Update(ctx, stsB)
@@ -533,7 +533,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 		log.V(1).Info("Detected up-to-date existing Backup StatefulSet", " StatefulSet.Name", stsB.Name)
 	}
 	// Primary (includes non-HA case)
-	if brokerStsOutdated(stsP, brokerSpecHash, tlsSecretHash) {
+	if brokerStsOutdated(stsP, brokerSpecHash, tlsSecretHash, tlsSecretResourceVersion) {
 		log.Info("Updating existing Primary StatefulSet", "StatefulSet.Namespace", stsP.Namespace, "StatefulSet.Name", stsP.Name)
 		r.updateStatefulsetForEventBroker(stsP, ctx, pubsubpluseventbroker, sa, adminSecret, preSharedAuthKeySecret, monitoringSecret)
 		err = r.Update(ctx, stsP)
@@ -587,7 +587,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 				r.recordErrorState(ctx, log, pubsubpluseventbroker, err, ResourceErrorReason, "Failed to list Monitor pod", "PubSubPlusEventBroker.Namespace", pubsubpluseventbroker.Namespace, "PubSubPlusEventBroker.Name", pubsubpluseventbroker.Name)
 				return ctrl.Result{}, err
 			}
-			if brokerPodOutdated(brokerPod, brokerSpecHash, tlsSecretHash) {
+			if brokerPodOutdated(brokerPod, brokerSpecHash, tlsSecretHash, tlsSecretResourceVersion) {
 				if brokerPod.ObjectMeta.DeletionTimestamp == nil {
 					// Restart the Monitor pod to sync with its Statefulset config
 					log.Info("Monitor pod outdated, restarting to reflect latest updates", "Pod.Namespace", &brokerPod.Namespace, "Pod.Name", &brokerPod.Name)
@@ -607,7 +607,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 				// Just requeue
 				return ctrl.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
 			}
-			if brokerPodOutdated(brokerPod, brokerSpecHash, tlsSecretHash) {
+			if brokerPodOutdated(brokerPod, brokerSpecHash, tlsSecretHash, tlsSecretResourceVersion) {
 				if brokerPod.ObjectMeta.DeletionTimestamp == nil {
 					// Restart the Standby pod to sync with its Statefulset config
 					log.Info("Standby pod outdated, restarting to reflect latest updates", "Pod.Namespace", &brokerPod.Namespace, "Pod.Name", &brokerPod.Name)
@@ -634,7 +634,7 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 				return ctrl.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
 			}
 		}
-		if brokerPodOutdated(brokerPod, brokerSpecHash, tlsSecretHash) {
+		if brokerPodOutdated(brokerPod, brokerSpecHash, tlsSecretHash, tlsSecretResourceVersion) {
 			if brokerPod.ObjectMeta.DeletionTimestamp == nil {
 				// Restart the Active Pod to sync with its Statefulset config
 				log.Info("Active pod outdated, restarting to reflect latest updates", "Pod.Namespace", &brokerPod.Namespace, "Pod.Name", &brokerPod.Name)
@@ -818,9 +818,10 @@ func (r *PubSubPlusEventBrokerReconciler) SetupWithManager(mgr ctrl.Manager) err
 	// Need to watch non-managed resources
 	// To understand following code refer to https://kubebuilder.io/reference/watching-resources/externally-managed.html#allow-for-linking-of-resources-in-the-spec
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &eventbrokerv1beta1.PubSubPlusEventBroker{}, dependencyTlsSecretField, func(rawObj client.Object) []string {
-		// Extract the secret name from the EventBroker Spec, if one is provided
+		// Extract the secret name from the EventBroker Spec, if TLS is enabled and one is provided.
+		// The Enabled check matters because serverTlsConfigSecret has a CRD default name.
 		eventBroker := rawObj.(*eventbrokerv1beta1.PubSubPlusEventBroker)
-		if eventBroker.Spec.BrokerTLS.ServerTLsConfigSecret == "" {
+		if !eventBroker.Spec.BrokerTLS.Enabled || eventBroker.Spec.BrokerTLS.ServerTLsConfigSecret == "" {
 			return nil
 		}
 		return []string{eventBroker.Spec.BrokerTLS.ServerTLsConfigSecret}

--- a/controllers/eventbroker_controller.go
+++ b/controllers/eventbroker_controller.go
@@ -503,6 +503,18 @@ func (r *PubSubPlusEventBrokerReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
+	// Migrate legacy resourceVersion-format TLS annotations (Operator <= 1.4.0) in place while they
+	// still provably reflect the current secret contents, avoiding a one-time restart on the first
+	// secret rewrite after Operator upgrade
+	stssForTlsMigration := []*appsv1.StatefulSet{stsP}
+	if haDeployment {
+		stssForTlsMigration = append(stssForTlsMigration, stsB, stsM)
+	}
+	if err := r.migrateLegacyTlsAnnotations(ctx, pubsubpluseventbroker, stssForTlsMigration, tlsSecretHash, tlsSecretResourceVersion); err != nil {
+		r.recordErrorState(ctx, log, pubsubpluseventbroker, err, ResourceErrorReason, "Failed to migrate TLS secret annotations")
+		return ctrl.Result{}, err
+	}
+
 	// Check and address if statefulsets require update
 	if haDeployment {
 		// Monitor

--- a/controllers/statefulset.go
+++ b/controllers/statefulset.go
@@ -177,9 +177,10 @@ func (r *PubSubPlusEventBrokerReconciler) updateStatefulsetForEventBroker(sts *a
 		}
 	}
 
+	tlsSecretContentHash, _ := r.tlsSecretHash(ctx, m)
 	podAnnotations := map[string]string{
 		brokerSpecSignatureAnnotationName: brokerSpecHash(m.Spec),
-		tlsSecretSignatureAnnotationName:  r.tlsSecretHash(ctx, m),
+		tlsSecretSignatureAnnotationName:  tlsSecretContentHash,
 	}
 	if len(m.Spec.PodAnnotations) > 0 {
 		for k, v := range m.Spec.PodAnnotations {

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -1994,7 +1994,7 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: ""
-        image: docker.io/solace/pubsubplus-eventbroker-operator:1.4.0
+        image: docker.io/solace/pubsubplus-eventbroker-operator:1.4.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/docs/EventBrokerOperatorUserGuide.md
+++ b/docs/EventBrokerOperatorUserGuide.md
@@ -583,7 +583,7 @@ Important: It is not possible to update an existing deployment (created without 
 
 In the event the server key or certificate must be rotated the TLS Config Secret must be updated or recreated with the new contents. Alternatively a new secret can be created and the broker spec can be updated with that secret's name.
 
-If you are reusing an existing TLS secret, the new contents are automatically mounted on the broker containers. The Operator is already watching the configured secret for any changes and automatically initiates a rolling pod restart to take effect. Deleting the existing TLS secret does not result in immediate action, but broker pods will not start if the specified TLS secret does not exist.
+If you are reusing an existing TLS secret, the new contents are automatically mounted on the broker containers. The Operator is already watching the configured secret for any changes and automatically initiates a rolling pod restart to take effect. Change detection is based on a hash of the secret's contents, so rewriting the secret with unchanged contents — for example through `kubectl replace`, a GitOps re-apply, or etcd encryption key rotation — does not restart broker pods. Deleting the existing TLS secret does not result in immediate action, but broker pods will not start if the specified TLS secret does not exist.
 
 > Note: A pod restart results in provisioning the server certificate from the secret again, so it reverts back from any other server certificate that might have been provisioned on the broker through another mechanism.
 

--- a/go.mod
+++ b/go.mod
@@ -70,3 +70,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+require github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/version.go
+++ b/version.go
@@ -15,4 +15,4 @@
 // limitations under the License.
 package main
 
-const version = "1.4.0"
+const version = "1.4.1"


### PR DESCRIPTION
### v1.4.1 Release

The Operator no longer triggers a rolling restart of broker pods when the TLS secret is rewritten with unchanged contents (e.g. kubectl replace, GitOps re-apply, or etcd encryption-key rotation). Change detection is now based on a salted SHA-256 hash of the secret's contents instead.
